### PR TITLE
runprism#28: `done` method in PrismTask class

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -30,7 +30,7 @@ jobs:
         pip install tox tox-gh-actions
     - name: Install docker
       run: |
-        brew install docker
+        brew install docker@24.0.3
         colima start
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -30,10 +30,15 @@ jobs:
         pip install tox tox-gh-actions
     - name: Install docker
       run: |
-        brew install docker@24.0.3
+        # Workaround for https://github.com/actions/runner-images/issues/8104
+        brew remove --ignore-dependencies qemu
+        curl -o ./qemu.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/dc0669eca9479e9eeb495397ba3a7480aaa45c2e/Formula/qemu.rb
+        brew install ./qemu.rb
+
+        brew install docker
         colima start
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+    # - name: Set up QEMU
+    #   uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Test with tox

--- a/prism/agents/base.py
+++ b/prism/agents/base.py
@@ -177,6 +177,7 @@ class Agent(metaclass=MetaAgent):
         tasks = self.args.tasks
         all_upstream = self.args.all_upstream
         all_downstream = self.args.all_downstream
+        full_refresh = self.args.full_refresh
 
         # Namespace to string conversion
         full_tb_cmd = "" if not full_tb else "--full-tb"
@@ -190,9 +191,10 @@ class Agent(metaclass=MetaAgent):
         ])
         all_upstream_cmd = "" if not all_upstream else "--all-upstream"
         all_downstream_cmd = "" if not all_downstream else "--all-downstream"
+        full_refresh_cmd = "" if not full_refresh else "--full-refresh"
 
         # Full command
-        full_cmd = f"prism run {full_tb_cmd} {log_level_cmd} {vars_cmd} {context_cmd} {tasks_cmd} {all_upstream_cmd} {all_downstream_cmd}"  # noqa: E501
+        full_cmd = f"prism run {full_tb_cmd} {log_level_cmd} {vars_cmd} {context_cmd} {tasks_cmd} {all_upstream_cmd} {all_downstream_cmd} {full_refresh_cmd}"  # noqa: E501
         return full_cmd
 
     def parse_environment_variables(self, agent_conf: Dict[str, Any]) -> Dict[str, str]:

--- a/prism/cli/run.py
+++ b/prism/cli/run.py
@@ -144,6 +144,7 @@ class RunTask(prism.cli.compile.CompileTask, prism.mixins.run.RunMixin):
             self.args.all_upstream,
             self.args.all_downstream,
             threads,
+            self.args.full_refresh,
             user_context
         )
 

--- a/prism/client/__init__.py
+++ b/prism/client/__init__.py
@@ -212,6 +212,7 @@ class PrismDAG(
         tasks: Optional[List[str]] = None,
         all_upstream: bool = True,
         all_downstream: bool = False,
+        full_refresh: bool = False,
         full_tb: bool = True,
         user_context: Optional[Dict[str, Any]] = None
     ):
@@ -275,6 +276,7 @@ class PrismDAG(
                 all_upstream,
                 all_downstream,
                 threads,
+                full_refresh,
                 user_context
             )
             pipeline = self.create_pipeline(

--- a/prism/decorators/target.py
+++ b/prism/decorators/target.py
@@ -74,7 +74,7 @@ def target(*, type, loc, **kwargs):
                     )
 
                 # If the task should be run in full, then call the run function
-                if self.bool_run:
+                if self.bool_run and not self.done(task_manager, hooks):
 
                     # When using `target` as a decorator, `run` is a function. When
                     # using `target` as an argument to the `task()` decorator, `run` is

--- a/prism/decorators/target.py
+++ b/prism/decorators/target.py
@@ -74,7 +74,7 @@ def target(*, type, loc, **kwargs):
                     )
 
                 # If the task should be run in full, then call the run function
-                if self.bool_run and not self.done(task_manager, hooks):
+                if self.bool_run and not self.is_done:
 
                     # When using `target` as a decorator, `run` is a function. When
                     # using `target` as an argument to the `task()` decorator, `run` is

--- a/prism/event_managers/base.py
+++ b/prism/event_managers/base.py
@@ -20,7 +20,8 @@ from typing import Any, Callable, List, Optional, Union
 import prism.prism_logging
 import prism.exceptions
 from prism.prism_logging import Event, fire_console_event, fire_empty_line_event
-from prism.ui import RED, GREEN, EVENT_COLOR, RESET
+from prism.ui import RED, GREEN, EVENT_COLOR, ORANGE, RESET
+from prism.infra.task_manager import PrismTaskManager
 
 
 ####################
@@ -60,7 +61,7 @@ class BaseEventManager:
         Create ExecutionEvent informing user that a task was skipped
         """
         e = prism.prism_logging.ExecutionEvent(
-            msg=f"SKIPPED EVENT {EVENT_COLOR}'{self.name}'{RESET}",
+            msg=f"{ORANGE}SKIPPING{RESET} EVENT {EVENT_COLOR}'{self.name}'{RESET}",
             num=self.idx,
             total=self.total,
             status="SKIP",
@@ -134,7 +135,6 @@ class BaseEventManager:
         event_list: List[prism.prism_logging.Event],
         fire_exec_events=True,
         fire_empty_line_events=True,
-        skipped_event=False,
         **kwargs
     ) -> EventManagerOutput:
         """
@@ -151,11 +151,18 @@ class BaseEventManager:
             # logic is handled within the task's `exec` function. So, we just run it
             # normally here.
             outputs = self.run(**kwargs)
-            if fire_exec_events:
-                if skipped_event:
-                    event_list = self.fire_skipped_exec_event(event_list)
-                else:
-                    event_list = self.fire_success_exec_event(start_time, event_list)
+
+            # Check if the output is a task manager. If it is, then we've run a task.
+            # Check if the task was skipped, and fire the corresponding event.
+            if isinstance(outputs, PrismTaskManager):
+                task_instance = outputs.upstream[self.name]
+                if fire_exec_events:
+                    if task_instance.is_done:
+                        event_list = self.fire_skipped_exec_event(event_list)
+                    else:
+                        event_list = self.fire_success_exec_event(start_time, event_list)  # noqa: E501
+            elif fire_exec_events:
+                event_list = self.fire_success_exec_event(start_time, event_list)
 
             # Return output of task execution
             return EventManagerOutput(outputs, None, event_list)

--- a/prism/infra/compiled_task.py
+++ b/prism/infra/compiled_task.py
@@ -188,6 +188,7 @@ class CompiledTask:
         task_manager: PrismTaskManager,
         hooks: PrismHooks,
         explicit_run: bool = True,
+        full_refresh: bool = False,
         user_context: Dict[Any, Any] = {},
     ) -> PrismTaskManager:
         """
@@ -197,7 +198,7 @@ class CompiledTask:
             run_context, task_manager, hooks, explicit_run, user_context
         )
         is_done = run_context[task_var_name].done(task_manager, hooks)
-        run_context[task_var_name].is_done = is_done
+        run_context[task_var_name].is_done = is_done and not full_refresh
 
         # Execute the task
         run_context[task_var_name].exec()

--- a/prism/infra/compiled_task.py
+++ b/prism/infra/compiled_task.py
@@ -22,15 +22,6 @@ from prism.infra.task_manager import PrismTaskManager
 from prism.infra.hooks import PrismHooks
 from prism.infra.manifest import TaskManifest
 from prism.parsers.ast_parser import AstParser
-from prism.prism_logging import (
-    fire_console_event,
-    ExecutionEvent
-)
-from prism.ui import (
-    ORANGE,
-    EVENT_COLOR,
-    RESET,
-)
 
 
 ####################
@@ -207,19 +198,8 @@ class CompiledTask:
         task_var_name = self.instantiate_task_class(
             run_context, task_manager, hooks, explicit_run, user_context
         )
-
-        # Check if the task is done
         is_done = run_context[task_var_name].done(task_manager, hooks)
         run_context[task_var_name].is_done = is_done
-        if is_done:
-            e = ExecutionEvent(
-                msg=f"{ORANGE}SKIPPING{RESET} EVENT {EVENT_COLOR}{task_var_name}{RESET}",  # noqa: E501
-                num=idx,
-                total=total,
-                status="SKIPPED",
-                execution_time=None
-            )
-            fire_console_event(e, [], log_level='info')
 
         # Execute the task
         run_context[task_var_name].exec()

--- a/prism/infra/compiled_task.py
+++ b/prism/infra/compiled_task.py
@@ -13,7 +13,7 @@ Table of Contents
 # Standard library imports
 import ast
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 import re
 
 # Prism-specific imports
@@ -189,8 +189,6 @@ class CompiledTask:
         hooks: PrismHooks,
         explicit_run: bool = True,
         user_context: Dict[Any, Any] = {},
-        idx: Optional[int] = None,
-        total: Optional[int] = None,
     ) -> PrismTaskManager:
         """
         Execute task

--- a/prism/infra/executor.py
+++ b/prism/infra/executor.py
@@ -212,7 +212,9 @@ class DagExecutor:
                 task_manager=task_manager,
                 hooks=hooks,
                 explicit_run=task.task_var_name not in self.nodes_not_explicitly_run,
-                user_context=user_context
+                user_context=user_context,
+                idx=idx,
+                total=total,
             )
 
             # All events

--- a/prism/infra/executor.py
+++ b/prism/infra/executor.py
@@ -57,10 +57,14 @@ class DagExecutor:
         user_arg_all_upstream: bool,
         user_arg_all_downstream: bool,
         threads: int,
-        user_context: Dict[Any, Any] = {}
+        full_refresh: bool = False,
+        user_context: Dict[Any, Any] = {},
     ):
         self.project_dir = project_dir
         self.compiled_dag = compiled_dag
+
+        # Refresh all `done` tasks as well
+        self.full_refresh = full_refresh
 
         # Extract attributes from compiled_dag instance
         self.compiled_tasks = self.compiled_dag.compiled_tasks
@@ -212,6 +216,7 @@ class DagExecutor:
                 task_manager=task_manager,
                 hooks=hooks,
                 explicit_run=task.task_var_name not in self.nodes_not_explicitly_run,
+                full_refresh=self.full_refresh,
                 user_context=user_context,
             )
 

--- a/prism/infra/executor.py
+++ b/prism/infra/executor.py
@@ -213,8 +213,6 @@ class DagExecutor:
                 hooks=hooks,
                 explicit_run=task.task_var_name not in self.nodes_not_explicitly_run,
                 user_context=user_context,
-                idx=idx,
-                total=total,
             )
 
             # All events

--- a/prism/main.py
+++ b/prism/main.py
@@ -280,6 +280,13 @@ def connect(
     help="Execute all tasks upstream of tasks specified with `--task`"
 )
 @click.option(
+    '--full-refresh',
+    is_flag=True,
+    default=False,
+    type=bool,
+    help="Run tasks from scratch (even the ones that are considered `done`)"
+)
+@click.option(
     '--log-level', '-l',
     type=click.Choice(['info', 'warn', 'error', 'debug']),
     default="info",
@@ -307,6 +314,7 @@ def run(
     task,
     all_downstream,
     all_upstream,
+    full_refresh,
     log_level,
     full_tb,
     vars,
@@ -331,8 +339,9 @@ def run(
     # Namespace
     ns = argparse.Namespace()
     ns.tasks = tasks_list
-    ns.all_upstream = all_upstream
     ns.all_downstream = all_downstream
+    ns.all_upstream = all_upstream
+    ns.full_refresh = full_refresh
     ns.full_tb = full_tb
     ns.log_level = log_level
     ns.vars = vars_dict
@@ -721,6 +730,13 @@ def agent_apply(
     help="Execute all tasks upstream of tasks specified with `--task`"
 )
 @click.option(
+    '--full-refresh',
+    is_flag=True,
+    default=False,
+    type=bool,
+    help="Run tasks from scratch (even the ones that are considered `done`)"
+)
+@click.option(
     '--log-level', '-l',
     type=click.Choice(['info', 'warn', 'error', 'debug']),
     default="info",
@@ -749,6 +765,7 @@ def agent_run(
     task,
     all_downstream,
     all_upstream,
+    full_refresh,
     log_level,
     full_tb,
     vars,
@@ -775,8 +792,9 @@ def agent_run(
     ns = argparse.Namespace()
     ns.file = file
     ns.tasks = tasks_list
-    ns.all_upstream = all_upstream
     ns.all_downstream = all_downstream
+    ns.all_upstream = all_upstream
+    ns.full_refresh = full_refresh
     ns.full_tb = full_tb
     ns.log_level = log_level
     ns.vars = vars_dict
@@ -815,6 +833,13 @@ def agent_run(
     help="Execute all tasks upstream of tasks specified with `--task`"
 )
 @click.option(
+    '--full-refresh',
+    is_flag=True,
+    default=False,
+    type=bool,
+    help="Run tasks from scratch (even the ones that are considered `done`)"
+)
+@click.option(
     '--log-level', '-l',
     type=click.Choice(['info', 'warn', 'error', 'debug']),
     default="info",
@@ -843,6 +868,7 @@ def agent_build(
     task,
     all_downstream,
     all_upstream,
+    full_refresh,
     log_level,
     full_tb,
     vars,
@@ -869,8 +895,9 @@ def agent_build(
     ns = argparse.Namespace()
     ns.file = file
     ns.tasks = tasks_list
-    ns.all_upstream = all_upstream
     ns.all_downstream = all_downstream
+    ns.all_upstream = all_upstream
+    ns.full_refresh = full_refresh
     ns.full_tb = full_tb
     ns.log_level = log_level
     ns.vars = vars_dict
@@ -951,6 +978,13 @@ def agent_delete(
     help="Execute all tasks upstream of tasks specified with `--task`."
 )
 @click.option(
+    '--full-refresh',
+    is_flag=True,
+    default=False,
+    type=bool,
+    help="Run tasks from scratch (even the ones that are considered `done`)"
+)
+@click.option(
     '--log-level', '-l',
     type=click.Choice(['info', 'warn', 'error', 'debug']),
     default="info",
@@ -978,6 +1012,7 @@ def spark_submit(
     task,
     all_downstream,
     all_upstream,
+    full_refresh,
     log_level,
     full_tb,
     vars,
@@ -1002,8 +1037,9 @@ def spark_submit(
     # Namespace
     ns = argparse.Namespace()
     ns.tasks = tasks_list
-    ns.all_upstream = all_upstream
     ns.all_downstream = all_downstream
+    ns.all_upstream = all_upstream
+    ns.full_refresh = full_refresh
     ns.full_tb = full_tb
     ns.log_level = log_level
     ns.vars = vars_dict

--- a/prism/prism_logging.py
+++ b/prism/prism_logging.py
@@ -45,6 +45,7 @@ from prism.ui import (
     HEADER_GRAY,
     GRAY_PINK,
     ORANGE_BROWN,
+    ORANGE,
     TERMINAL_WIDTH,
 )
 
@@ -62,7 +63,7 @@ def colorize_status(status):
     returns
         colorized_status: status with color
     """
-    if status not in ["RUN", "DONE", "ERROR"]:
+    if status not in ["RUN", "DONE", "ERROR", "SKIPPED"]:
         raise ValueError(f"{status} is invalid; must be either RUN, DONE, or ERROR")
     if status == "RUN":
         return f"{YELLOW}RUN{RESET}"
@@ -70,6 +71,8 @@ def colorize_status(status):
         return f"{GREEN}DONE{RESET}"
     elif status == "ERROR":
         return f"{RED}ERROR{RESET}"
+    elif status == "SKIPPED":
+        return f"{ORANGE}SKIPPED{RESET}"
 
 
 def escape_ansi(string: str) -> str:
@@ -448,6 +451,7 @@ class ExecutionEvent(Event):
             RUNNING EVENT {event.name}
             FINISHED EVENT {event.name}
             ERROR IN EVENT {event.name}
+            SKIPPED EVENT {event.name}
 
         Add name of event (after removing event status and ANSI codes) to string
         representation of event.
@@ -456,7 +460,7 @@ class ExecutionEvent(Event):
         msg_no_ansi = escape_ansi(self.msg)
 
         # Remove the event status
-        status_regex = re.compile('(RUNNING|FINISHED|ERROR)')
+        status_regex = re.compile('(RUNNING|FINISHED|ERROR|SKIPPED)')
         msg_no_ansi_status = status_regex.sub('', msg_no_ansi)
 
         # Remove EVENT and quotation marks

--- a/prism/prism_logging.py
+++ b/prism/prism_logging.py
@@ -63,16 +63,16 @@ def colorize_status(status):
     returns
         colorized_status: status with color
     """
-    if status not in ["RUN", "DONE", "ERROR", "SKIPPED"]:
-        raise ValueError(f"{status} is invalid; must be either RUN, DONE, or ERROR")
+    if status not in ["RUN", "DONE", "ERROR", "SKIP"]:
+        raise ValueError(f"{status} is invalid; must be either RUN, DONE, ERROR, or SKIP")  # noqa
     if status == "RUN":
         return f"{YELLOW}RUN{RESET}"
     elif status == "DONE":
         return f"{GREEN}DONE{RESET}"
     elif status == "ERROR":
         return f"{RED}ERROR{RESET}"
-    elif status == "SKIPPED":
-        return f"{ORANGE}SKIPPED{RESET}"
+    elif status == "SKIP":
+        return f"{ORANGE}SKIP{RESET}"
 
 
 def escape_ansi(string: str) -> str:
@@ -460,7 +460,7 @@ class ExecutionEvent(Event):
         msg_no_ansi = escape_ansi(self.msg)
 
         # Remove the event status
-        status_regex = re.compile('(RUNNING|FINISHED|ERROR|SKIPPED)')
+        status_regex = re.compile('(RUNNING|FINISHED|ERROR|SKIPPING)')
         msg_no_ansi_status = status_regex.sub('', msg_no_ansi)
 
         # Remove EVENT and quotation marks

--- a/prism/task.py
+++ b/prism/task.py
@@ -97,7 +97,7 @@ class PrismTask:
         returns:
             True if the task is already Done, False if not. Defaults to False.
         """
-        False
+        return False
 
     def run(self,
         tasks: prism.infra.task_manager.PrismTaskManager,

--- a/prism/task.py
+++ b/prism/task.py
@@ -49,7 +49,7 @@ class PrismTask:
         self.RETRY_DELAY_SECONDS = 0
 
         # Initialize the is_done attribute
-        self.is_done: bool
+        self.is_done: bool = False
 
     def set_task_manager(self, task_manager: prism.infra.task_manager.PrismTaskManager):
         self.task_manager = task_manager

--- a/prism/task.py
+++ b/prism/task.py
@@ -83,6 +83,22 @@ class PrismTask:
                     "`run` method must produce a non-null output"
                 )
 
+    def done(self,
+        tasks: prism.infra.task_manager.PrismTaskManager,
+        hooks: prism.infra.hooks.PrismHooks,
+    ) -> bool:
+        """
+        Check if this task is already done. If it is, then don't execute `run`.
+        Otherwise, execute `run`.
+
+        args:
+            tasks: Prism task manager, used to reference other tasks
+            hooks: Prism hooks, used to access Prism adapters
+        returns:
+            True if the task is already Done, False if not. Defaults to False.
+        """
+        False
+
     def run(self,
         tasks: prism.infra.task_manager.PrismTaskManager,
         hooks: prism.infra.hooks.PrismHooks,
@@ -90,6 +106,11 @@ class PrismTask:
         """
         Run the task. The user should override this function definition when creating
         their own tasks.
+        args:
+            tasks: Prism task manager, used to reference other tasks
+            hooks: Prism hooks, used to access Prism adapters
+        returns:
+            Any
         """
         if self.func is not None:
             return self.func(tasks, hooks)

--- a/prism/task.py
+++ b/prism/task.py
@@ -48,6 +48,9 @@ class PrismTask:
         self.RETRIES = 0
         self.RETRY_DELAY_SECONDS = 0
 
+        # Initialize the is_done attribute
+        self.is_done: bool
+
     def set_task_manager(self, task_manager: prism.infra.task_manager.PrismTaskManager):
         self.task_manager = task_manager
 
@@ -58,7 +61,7 @@ class PrismTask:
 
         # If the `target` decorator isn't applied, then only execute the `run` function
         # of bool_run is true
-        if self.run.__name__ == "run":
+        if self.run.__name__ == "run" and not self.is_done:
 
             # If bool_run, then execute the `run` function and set the `output`
             # attribute to its result
@@ -140,7 +143,7 @@ class PrismTask:
                     )
 
                 # If the task should be run in full, then call the run function
-                if self.bool_run:
+                if self.bool_run and not self.is_done:
                     obj = func(self, task_manager, hooks)
 
                     # Initialize an instance of the target class and save the object

--- a/prism/tests/integration/test_projects/023_skipped_task/output/task01.txt
+++ b/prism/tests/integration/test_projects/023_skipped_task/output/task01.txt
@@ -1,1 +1,0 @@
-Hello from task 1!

--- a/prism/tests/integration/test_projects/023_skipped_task/output/task01.txt
+++ b/prism/tests/integration/test_projects/023_skipped_task/output/task01.txt
@@ -1,0 +1,1 @@
+Hello from task 1!

--- a/prism/tests/integration/test_projects/023_skipped_task/prism_project.py
+++ b/prism/tests/integration/test_projects/023_skipped_task/prism_project.py
@@ -1,0 +1,53 @@
+"""
+Prism project
+"""
+
+# Imports
+import logging
+from pathlib import Path
+from prism.admin import generate_run_id, generate_run_slug
+
+
+# Project metadata
+NAME = ""
+AUTHOR = ""
+VERSION = ""
+DESCRIPTION = """
+"""
+
+# Admin
+RUN_ID = generate_run_id()  # don't delete this!
+SLUG = generate_run_slug()  # don't delete this!
+
+
+# sys.path config. This gives your tasks access to local tasks / packages that exist
+# outside of your project structure.
+SYS_PATH_CONF = [
+    Path(__file__).parent,
+    Path(__file__).parent.parent,
+]
+
+
+# Thread count: number of workers to use to execute tasks concurrently. If set to 1,
+# then 1 task is run at a time.
+THREADS = 1
+
+
+# Profile directory and name
+PROFILE_YML_PATH = Path(__file__).parent / 'profile.yml'
+PROFILE = None  # name of profile within `profiles.yml`
+
+
+# Logger
+PRISM_LOGGER = logging.getLogger("PRISM_LOGGER")
+
+
+# Other variables / parameters. Make sure to capitalize all of these!
+VAR_1 = {'a': 'b'}
+VAR_2 = 200
+VAR_3 = '2015-01-01'
+
+# Paths
+WKDIR = Path(__file__).parent
+DATA = WKDIR / 'data'
+OUTPUT = WKDIR / 'output'

--- a/prism/tests/integration/test_projects/023_skipped_task/tasks/task01.py
+++ b/prism/tests/integration/test_projects/023_skipped_task/tasks/task01.py
@@ -1,0 +1,45 @@
+
+###########
+# Imports #
+###########
+
+# Prism infrastructure imports
+import prism.task
+import prism.target
+import prism.decorators
+
+# Prism project imports
+import prism_project
+
+# Other imports
+from pathlib import Path
+
+
+####################
+# Class definition #
+####################
+
+class Task01(prism.task.PrismTask):
+
+    def done(self, tasks, hooks):
+        return (Path(prism_project.OUTPUT) / 'task01.txt').is_file()
+
+    # Run
+    @prism.decorators.target(
+        type=prism.target.Txt,
+        loc=Path(prism_project.OUTPUT) / 'task01.txt'
+    )
+    def run(self, tasks, hooks):
+        """
+        Execute task.
+
+        args:
+            tasks: used to reference output of other tasks --> tasks.ref('...')
+            hooks: built-in Prism hooks. These include:
+            - hooks.dbt_ref --> for getting dbt tasks as a pandas DataFrame
+            - hooks.sql     --> for executing sql query using an adapter in profile YML
+            - hooks.spark   --> for accessing SparkSession
+        returns:
+            task output
+        """
+        return "Hello from task 1!"

--- a/prism/tests/integration/test_projects/023_skipped_task/tasks/task02.py
+++ b/prism/tests/integration/test_projects/023_skipped_task/tasks/task02.py
@@ -1,0 +1,45 @@
+
+###########
+# Imports #
+###########
+
+# Prism infrastructure imports
+import prism.task
+import prism.target
+import prism.decorators
+
+# Prism project imports
+import prism_project
+
+# Other imports
+from pathlib import Path
+
+
+####################
+# Class definition #
+####################
+
+class Task02(prism.task.PrismTask):
+
+    # Run
+    @prism.decorators.target(
+        type=prism.target.Txt,
+        loc=Path(prism_project.OUTPUT) / 'task02.txt'
+    )
+    def run(self, tasks, hooks):
+        """
+        Execute task.
+
+        args:
+            tasks: used to reference output of other tasks --> tasks.ref('...')
+            hooks: built-in Prism hooks. These include:
+            - hooks.dbt_ref --> for getting dbt tasks as a pandas DataFrame
+            - hooks.sql     --> for executing sql query using an adapter in profile YML
+            - hooks.spark   --> for accessing SparkSession
+        returns:
+            task output
+        """
+        with open(tasks.ref('task01.py'), 'r') as f:
+            lines = f.read()
+        f.close()
+        return lines + "\n" + "Hello from task 2!"

--- a/prism/tests/integration/test_run.py
+++ b/prism/tests/integration/test_run.py
@@ -1497,3 +1497,49 @@ class TestRunIntegration(integration_test_class.IntegrationTestCase):
 
         # Set up wkdir for the next test case
         self._set_up_wkdir()
+
+    def test_project_with_skipped_task(self):
+        """
+        If the `done` method is satisfied, then the task is skipped.
+        """
+        self.maxDiff = None
+
+        # Set working directory
+        wkdir = Path(TEST_PROJECTS) / '023_skipped_task'
+        os.chdir(wkdir)
+
+        # Update logger streamer
+        new_streamer = StringIO()
+        string_stream_handler.setStream(new_streamer)
+
+        # Remove the .compiled directory, if it exists
+        self._remove_compiled_dir(wkdir)
+
+        # Check that previous output exists
+        self.assertTrue((wkdir / 'output' / 'task01.txt').is_file())
+
+        # ------------------------------------------
+        # Execute command.
+
+        args = ['run']
+        run = self._run_prism(args)
+        run_results = run.get_results()
+        expected_events = run_success_starting_events + \
+            ['TasksHeaderEvent'] + \
+            _execution_events_tasks({
+                'task01.Task01': 'SKIP',
+                'task02.Task02': 'DONE',
+            }) + _run_task_end_events('TaskSuccessfulEndEvent')
+        self.assertEqual(' | '.join(expected_events), run_results)
+
+        # Check new output
+        self.assertTrue((wkdir / 'output' / 'task02.txt').is_file())
+
+        # Remove the .compiled directory, if it exists
+        self._remove_compiled_dir(wkdir)
+
+        # Remove the second task's output
+        os.unlink((wkdir / 'output' / 'task02.txt'))
+
+        # Set up wkdir for the next test case
+        self._set_up_wkdir()

--- a/prism/ui.py
+++ b/prism/ui.py
@@ -26,6 +26,7 @@ BOLD = "\u001b[1m"
 HEADER_GRAY = "\u001b[0m"
 GRAY_PINK = "\u001b[38;5;96m"
 ORANGE_BROWN = "\u001b[38;5;180m"
+ORANGE = "\u001b[38;5;208m"
 
 # Event colors
 EVENT_COLOR = "\u001b[38;5;103m"


### PR DESCRIPTION
In this PR, we implement the following changes:
- Add a `done` method to the PrismTask class
- Update the `BaseEventManager.manage_events_during_run` method to fire a `SKIPPED EVENT ...` execution event when we encounter a task that is already done.
- Adds a `--full-refresh` option to the `run` and `spark-submit` commands (and their agent counterparts). This option allows users to run tasks that are `done`